### PR TITLE
Removed "Node Package Manager" in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,9 +42,9 @@ Check `docs/index.html` and `docs/dist/docs.js` for an example setup.
 
 **Heads up:** the example `index.html` file needs to be served from a webserver (such as Apache, Nginx, IIS or similar) unless you change the file sources to include http or https. e.g. change `//cdn.plyr.io/1.6.11/plyr.js` to `https://cdn.plyr.io/1.6.11/plyr.js`
 
-### Node Package Manager (NPM)
+### `npm`
 
-Using NPM, you can grab Plyr:
+Using `npm`, you can grab Plyr:
 ```
 npm install plyr
 ```


### PR DESCRIPTION
`npm` does not stand for "Node Package Manager" because `npm` is not an acronym. It is a bacronymic abbreviation for "npm is not an acronym".

https://www.quora.com/I-keep-hearing-NPM-doesnt-stand-for-Node-Package-Manager-what-does-it-stand-for
